### PR TITLE
Log deploy, set force_checkout

### DIFF
--- a/nbviewer/init.sls
+++ b/nbviewer/init.sls
@@ -18,8 +18,13 @@ nbviewer-git:
     - rev: {{ salt['pillar.get']('nbviewer:rev', 'master') }}
     - target: /usr/share/nbviewer
     - force: true
+    - force_checkout: true
     - require:
       - pkg: git
+
+logdeploy:
+  cmd.run:
+    - name: "cd /usr/share/nbviewer && git log -1 --format='Deployed nbviewer %h %s' | logger"
 
 # Install all the dependencies for nbviewer via its requirements.txt into a virtualenv
 /usr/share/nbviewer/venv:


### PR DESCRIPTION
### Log deploy

Use git log to log the deployment to logger

```
git log -1 --format='Deployed nbviewer %h %s'
```

At first glance I didn't see a way to send to syslog or rsyslog through states. Additionally, the git module had no git.log command, so I just used cmd.run.
### Force checkout

Force a checkout even if there might be overwritten changes
