### PR TITLE
Supervisor order

### DIFF
--- a/firewall/init.sls
+++ b/firewall/init.sls
@@ -1,6 +1,6 @@
 # iptables -A PREROUTING -t nat -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080
 
-http:
+http-redirect:
     iptables.append:
         - chain: PREROUTING
         - table: nat

--- a/nbviewer/init.sls
+++ b/nbviewer/init.sls
@@ -31,3 +31,35 @@ logdeploy:
     virtualenv.manage:
         - requirements: /usr/share/nbviewer/requirements.txt
         - clear: false
+
+# Manage the service with nbviewer
+/etc/supervisor/conf.d/nbviewer.conf:
+    file.managed:
+        - source: salt://supervisor/nbviewer.conf.jinja
+        - template: jinja
+        - mode: 644
+        - defaults:
+            environment: 'HELLO="WORLD"'
+        {% if pillar['supervisor']['environment'] != '' %}
+        - context:
+            environment: '{{ pillar['supervisor']['environment'] }}'
+        {% endif %}
+
+# Reread any configuration file changes
+reread:
+    cmd.run:
+        - name: supervisorctl reread
+        - watch:
+            - file: /etc/supervisor/conf.d/nbviewer.conf
+
+# Update from config
+update:
+    cmd.run:
+        - name: supervisorctl update
+        - watch:
+            - file: /etc/supervisor/conf.d/nbviewer.conf
+
+# Restart the process
+restart:
+    cmd.run:
+        - name: supervisorctl restart nbviewer

--- a/supervisor/init.sls
+++ b/supervisor/init.sls
@@ -2,35 +2,7 @@ supervisor_install:
     pkg.installed:
         - name: supervisor
 
-/etc/supervisor/conf.d/nbviewer.conf:
-    file.managed:
-        - source: salt://supervisor/nbviewer.conf.jinja
-        - template: jinja
-        - mode: 644
-        - defaults:
-            environment: 'HELLO="WORLD"'
-        {% if pillar['supervisor']['environment'] != '' %}
-        - context:
-            environment: '{{ pillar['supervisor']['environment'] }}'
-        {% endif %}
-
 supervisor:
     service:
         - running
         - enable: True
-        - reload: True
-        - watch:
-            - file: /etc/supervisor/conf.d/nbviewer.conf
-
-reread:
-    cmd.run:
-        - name: supervisorctl reread
-        - watch:
-            - file: /etc/supervisor/conf.d/nbviewer.conf
-
-update:
-    cmd.run:
-        - name: supervisorctl update
-        - watch:
-            - file: /etc/supervisor/conf.d/nbviewer.conf
-


### PR DESCRIPTION
This moves all supervisorctl commands to live alongside deployment of nbviewer itself. This makes sure the config gets (re)loaded/updated at the right time and that the supervisor process for nbviewer restarts after the code deployment is finished.

Additionally, the firewall rule's name has been changed to `http-redirect`.
