### PR TITLE
Add libmemcached-dev to nbviewer state

### DIFF
--- a/nbviewer/init.sls
+++ b/nbviewer/init.sls
@@ -10,6 +10,7 @@ packages:
       - pandoc
       - libevent-dev
       - libcurl4-gnutls-dev
+      - libmemcached-dev
 
 # Pull down the current codebase of nbviewer from github, unless pillar has something else for us
 nbviewer-git:


### PR DESCRIPTION
This adds libmemcached-dev as a binary dependency within the nbviewer state, in case memcache was not installed on the same box.
