### PR TITLE
Add memcache10 dependency

### DIFF
--- a/memcache/init.sls
+++ b/memcache/init.sls
@@ -4,6 +4,7 @@ memcached:
           - memcached
           - libmemcached-dev
           - libmemcache-dev
+          - libmemcached10
           - zlib1g-dev
     file.managed:
         - name: /etc/memcached.conf


### PR DESCRIPTION
With the change to the Ubuntu version we're using, this installs one other necessary memcached dependency.
