### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+# Minimal Travis verfication for salt states
+
 # Since salt/salt states aren't a language proper, this is a hackaround for now
-# I could probably add this to travis later.
-# https://github.com/travis-ci/travis-ci/issues/1549
+# We should probably build a basebox for travis at some point
+#    (see https://github.com/travis-ci/travis-ci/issues/1549)
 language: python
 python:
 - '2.7'
@@ -9,21 +11,25 @@ before_install:
   - sudo apt-get update
   # Install salt master and salt minion on the same box
   - curl -L http://bootstrap.saltstack.org | sudo sh -s -- git develop
+  # Set up our installation bits
+  - sudo mkdir -p /srv/salt/states
+  - sudo cp .travis/minion /etc/salt/minion
 
 install:
-  # Copy these states 
-  - sudo mkdir -p /srv/salt/states
+  # Copy the states and restart
   - sudo cp -r . /srv/salt/states
-  - sudo cp .travis/minion /etc/salt/minion
   - sudo service salt-minion restart
-  # Additional debug help
+
+  # If anything bad happened on restarting the minion,
+  # we'll want to see the logs
   - sudo cat /var/log/salt/*
-  # See what's available on travis
+
+  # For additional debugging, see what's in grains on a travis box
   - sudo salt-call grains.items --local
 
-#script: sudo salt '*' state.highstate
 script:
   - sudo salt-call state.show_highstate --local
   - sudo salt-call state.show_lowstate --local
+  # Next step is doing some verification of the run
   #- sudo salt-call state.highstate --local
   #- wget 127.0.0.1:8888

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+# Since salt/salt states aren't a language proper, this is a hackaround for now
+# I could probably add this to travis later.
+# https://github.com/travis-ci/travis-ci/issues/1549
+language: python
+python:
+- '2.7'
+
+before_install:
+  - sudo apt-get update
+  # Install salt master and salt minion on the same box
+  - curl -L http://bootstrap.saltstack.org | sudo sh -s -- git develop
+
+install:
+  # Copy these states 
+  - sudo mkdir -p /srv/salt/states
+  - sudo cp -r . /srv/salt/states
+  - sudo cp .travis/minion /etc/salt/minion
+  - sudo service salt-minion restart
+  # Additional debug help
+  - sudo cat /var/log/salt/*
+  # See what's available on travis
+  - sudo salt-call grains.items --local
+
+#script: sudo salt '*' state.highstate
+script:
+  - sudo salt-call state.show_highstate --local
+  - sudo salt-call state.show_lowstate --local
+  #- sudo salt-call state.highstate --local
+  #- wget 127.0.0.1:8888

--- a/.travis/master
+++ b/.travis/master
@@ -1,0 +1,5 @@
+fileserver_backend:
+  - roots
+file_roots:
+  base:
+    - /srv/states/

--- a/.travis/master
+++ b/.travis/master
@@ -1,5 +1,0 @@
-fileserver_backend:
-  - roots
-file_roots:
-  base:
-    - /srv/states/

--- a/.travis/minion
+++ b/.travis/minion
@@ -1,0 +1,4 @@
+file_client: local
+file_roots:
+  base:
+    - /srv/salt/states

--- a/nbviewer/init.sls
+++ b/nbviewer/init.sls
@@ -39,12 +39,8 @@ logdeploy:
         - source: salt://supervisor/nbviewer.conf.jinja
         - template: jinja
         - mode: 644
-        - defaults:
-            environment: 'HELLO="WORLD"'
-        {% if pillar['supervisor']['environment'] != '' %}
         - context:
-            environment: '{{ pillar['supervisor']['environment'] }}'
-        {% endif %}
+            environment: '{{ salt['pillar.get']('supervisor:environment', '')}}'
 
 # Reread any configuration file changes
 reread:

--- a/syslog/init.sls
+++ b/syslog/init.sls
@@ -1,3 +1,4 @@
+{% if 'logentries' in pillar %}
 rsyslog-gnutls:
     pkg.installed
 
@@ -16,3 +17,5 @@ rsyslog:
         - reload: True
         - watch:
             - file: /etc/rsyslog.d/nbviewer.conf
+
+{% endif %}


### PR DESCRIPTION
This adds some minor travis support to the salt states, by setting up salt and deploying the salt states to a travis box. I made a [little post about using travis for salt states](http://blog.fict.io/automation/travis/travis%20ci/configuration%20management/continuous%20integration/salt/chef/saltstack/salt%20stack/2014/01/29/travis-for-salt-states/), as I haven't seen anyone else doing this yet. Some things that will need to change in a later PR.
- Actual checking of the validation step (salt will return 0 when running show_highstate even if it failed, because it thinks that it **successfully performed work on the minion** rather than **this was successful on each and every minion**.
- Verification that nbviewer fully deployed and works
- Setup GitHub triggers to fire builds off when either ipython/nbviewer or ipython/salt-states-nbviewer changes

I also handled empty pillar entries better (for the sake of travis).
