### PR TITLE
Back to old setuptools and pip ways...

### DIFF
--- a/python/init.sls
+++ b/python/init.sls
@@ -7,8 +7,17 @@ base-deps:
       - wget
       - curl
       - python-dev
-      - python-setuptools
-      - python-pip
+    - reload_modules: true
+
+# Install the most recent version of setuptools
+setuptools:
+  cmd.run:
+    - name: wget https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py -O - | python2.7
+
+# Install the most recent version of pip, manually
+pippin:
+  cmd.run:
+    - name: curl --show-error --retry 5 https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python2.7
     - reload_modules: true
 
 virtualenv:


### PR DESCRIPTION
On a fresh deploy, I'm having trouble getting salt to reload the pip and virtualenv modules which ends up cascading errors down. Since Travis already has these by default, there's no problem. Fresh install isn't happy though and requires two `highstate` runs on the initial setup.

This just reverts us back to the non-idempotent always install pip + setuptools path. I'll have to re-visit this, but I want the deployment to be clean.
