### PR TITLE
Move libmemcached to nbviewer state

### DIFF
--- a/memcache/init.sls
+++ b/memcache/init.sls
@@ -1,17 +1,3 @@
-# Handle naming differences for current production boxes, future boxes,
-# Travis CI.
-
-{% if grains['os'] == 'Ubuntu' %}
-  {% if grains['osrelease'] in ['12.10', '13.04', '13.10'] %}
-    {% set libmemcached = "libmemcached10" %}
-  {% else %} # grains['osrelease'] == '12.04' %}
-    {% set libmemcached = "libmemcached6" %}
-  {% endif %}
-{% else %}
-    # Default to libmemcached6 otherwise
-    {% set libmemcached = "libmemcached6" %}
-{% endif %}
-
 memcached:
     pkg.installed:
         - names:

--- a/memcache/init.sls
+++ b/memcache/init.sls
@@ -4,7 +4,6 @@ memcached:
           - memcached
           - libmemcached-dev
           - libmemcache-dev
-          - {{ libmemcached }}
           - zlib1g-dev
     file.managed:
         - name: /etc/memcached.conf

--- a/nbviewer/init.sls
+++ b/nbviewer/init.sls
@@ -1,3 +1,17 @@
+# Handle naming differences for current production boxes, future boxes,
+# Travis CI.
+
+{% if grains['os'] == 'Ubuntu' %}
+  {% if grains['osrelease'] in ['12.10', '13.04', '13.10'] %}
+    {% set libmemcached = "libmemcached10" %}
+  {% else %} # grains['osrelease'] == '12.04' %}
+    {% set libmemcached = "libmemcached6" %}
+  {% endif %}
+{% else %}
+    # Default to libmemcached6 otherwise
+    {% set libmemcached = "libmemcached6" %}
+{% endif %}
+
 # nbviewer binary dependencies
 packages:
   pkg:
@@ -9,6 +23,7 @@ packages:
       - libevent-dev
       - libcurl4-gnutls-dev
       - libmemcached-dev
+      - {{ libmemcached }}
       - supervisor
 
 # Pull down the current codebase of nbviewer from github, unless pillar has something else for us
@@ -32,6 +47,8 @@ logdeploy:
     virtualenv.manage:
         - requirements: /usr/share/nbviewer/requirements.txt
         - clear: false
+        - require:
+          - pkg: libmemcached-dev
 
 # nbviewer gets managed by supervisor
 nbviewer:


### PR DESCRIPTION
Moving libmemcached to the nbviewer state.

Without it, the first run ends up having installation issues with the Python package for memcache

```
                  _pylibmcmodule.h:42:36: fatal error: libmemcached/memcached.h: No such file or directory
                   #include <libmemcached/memcached.h>
                                                      ^
```
