### PR TITLE
Use libcurl4-openssl-dev

### DIFF
--- a/nbviewer/init.sls
+++ b/nbviewer/init.sls
@@ -21,7 +21,7 @@ packages:
       - libzmq3-dev
       - pandoc
       - libevent-dev
-      - libcurl4-gnutls-dev
+      - libcurl4-openssl-dev
       - libmemcached-dev
       - {{ libmemcached }}
       - supervisor


### PR DESCRIPTION
This ensures the `libcurl4-openssl-dev` library gets installed instead of the gnutls one.

I've got another patch I'll submit later that makes sure pycurl compiles against openssl instead of gnutls, but I want to see how this works out on a fresh box.
