### PR TITLE
Use pip name, not util name

### DIFF
--- a/newrelic/init.sls
+++ b/newrelic/init.sls
@@ -23,7 +23,7 @@ newrelic-sysmond-conf:
     - require:
       - pkg: newrelic-sysmond
 
-newrelic-admin:
+newrelic:
   pip.installed
 
 newrelic-plugin-agent:


### PR DESCRIPTION
In my last PR, I used the name of one of the scripts that gets installed rather than the name from pip. Oops. This fixes that.
