### PR TITLE
Quote key

### DIFF
--- a/newrelic/newrelic.ini
+++ b/newrelic/newrelic.ini
@@ -33,7 +33,7 @@ license_key = {{ pillar['newrelic']['license_key'] }}
 # application as you would like it to show up in New Relic UI.
 # The UI will then auto-map instances of your application into a
 # entry on your home dashboard page.
-app_name = Python Application
+app_name = Notebook Viewer
 
 # When "true", the agent collects performance data about your
 # application and reports this data to the New Relic UI at

--- a/newrelic/newrelic.ini
+++ b/newrelic/newrelic.ini
@@ -27,7 +27,7 @@
 # You must specify the license key associated with your New
 # Relic account. This key binds the Python Agent's data to your
 # account in the New Relic service.
-license_key = "{{ pillar['newrelic']['license_key'] }}"
+license_key = {{ pillar['newrelic']['license_key'] }}
 
 # The appplication name. Set this to be the name of your
 # application as you would like it to show up in New Relic UI.


### PR DESCRIPTION
The quotes around the new relic key were invalid. The New Relic application monitoring should work now.

To find this, I tested a working config locally and did a diff against what we had in production with what was on my local box.

While I was at it I set the name of the application to "Notebook Viewer" (minus quotes :wink:)
